### PR TITLE
Fix table name typo in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@
     Date:       2025-06-11
 --------------------------------------------------------------------------------
     Description:
-    1. Creates a cleaned table 'registration_clean_with visits' from the patient registration
+    1. Creates a cleaned table 'registration_clean_with_visits' from the patient registration
        cards (healthtail_reg_cards):
         - Converts patient names to uppercase
         - Cleans the phone numbers to keep digits only


### PR DESCRIPTION
## Summary
- correct registration table name in README introductory section

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_685136b846c88327af404b8fb480989b